### PR TITLE
use arma:: prefix to fix compilation with armadillo 9.400+

### DIFF
--- a/inst/include/sgl/objective/sgl_gl_loss_base.h
+++ b/inst/include/sgl/objective/sgl_gl_loss_base.h
@@ -404,7 +404,7 @@ inline void GenralizedLinearLossBase < T , E >::compute_hessian_norm() const
 
 	//NOTE norm configable, 2-norm, 1-norm
 
-	partial_hessian_norm = sqrt(as_scalar(max(sum(square(partial_hessian), 1))));
+	partial_hessian_norm = sqrt(arma::as_scalar(arma::max(arma::sum(arma::square(partial_hessian), 1))));
 	//partial_hessian_norm = as_scalar(max(sum(abs(partial_hessian), 1)));
 
 	level0_bound = partial_hessian_norm * x_norm_max;


### PR DESCRIPTION
@nielsrhansen Armadillo 9.400+ (and the upcoming corresponding RcppArmadillo release) has more optimisations for various expressions. This PR is a one line change to fix a minor issue in sglOptim to allow compilation with Armadillo 9.400+.

See also the related issue at GitLab where the fixes for sglOptim and msgl are discussed in more detail: https://gitlab.com/conradsnicta/armadillo-code/issues/119

CC: @eddelbuettel
