### PR TITLE
Simplify includes and only include RcppArmadillo.h

### DIFF
--- a/inst/include/sgl.h
+++ b/inst/include/sgl.h
@@ -21,13 +21,12 @@
 
 #define R_NO_REMAP
 
+//R, Rcpp, RcppArmadillo
+#include <RcppArmadillo.h>
+
 //Progress monitor
 #include <progress.hpp>
 
-//Rcpp ect
-#include <RcppCommon.h>
-#include <Rconfig.h>
-#include <RcppArmadilloConfig.h>
 
 // Debugging
 #ifdef SGL_DEBUG
@@ -45,7 +44,9 @@
 #else
 // Do no debugging
 #define ARMA_NO_DEBUG
+#ifndef NDEBUG
 #define NDEBUG
+#endif
 #endif
 
 // Registration helper macros
@@ -59,11 +60,6 @@
 
 #define CALL_METHOD(METHOD, MODULE, ARGS) {GET_STR_VALUE(FUN_NAME(METHOD,MODULE)), (DL_FUNC) &r_ ## MODULE ## _ ## METHOD, ARGS}
 
-//Support for xl matrices
-//#define ARMA_64BIT_WORD
-
-#include <armadillo>
-#include <Rcpp.h>
 
 //Boost
 #include <boost/math/special_functions/fpclassify.hpp>


### PR DESCRIPTION
As detailed in [issue #400 in the RcppArmadillo repo](https://github.com/RcppCore/RcppArmadillo/issues/400) we would like to (re)move some _internal_ header files. `sglOptim` is one of very packages directly accessing one of these, and this PR suggests a simple way to not do this and to directly (and only) include `RcppArmadillo.h`.  (The linked issue ticked also mentions new 'lighter' header files so you could try `#include <RcppArmadillo/Lighter>`; I have not done this here.)  It looks like you had to do some manual defining and configuring back in the day, none of this should be needed now.

With this PR, the package still builds and checks cleanly for me.  It would be lovely if you could consider this, possible merge this and get an updated version to CRAN in the next few months.  If you do so, please leave a comment to at the linked issue so that we can keep track.  Thanks for your consideration, and please don't hesitate to ask if anything seems unclear. 